### PR TITLE
Add utilities for Persian numbers and dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ background type and applied effects.
 ![](images/00007.png)
 #### 
 ![](images/00008.png)
+
+## Utility Functions
+Two helper functions in `persian_utils.py` generate Persian numbers and dates.
+
+```python
+from persian_utils import generate_persian_number, get_persian_date
+print(generate_persian_number())  # ۱۰-digit Persian digits
+print(get_persian_date())        # current Persian date
+```

--- a/persian_utils.py
+++ b/persian_utils.py
@@ -1,0 +1,49 @@
+import random
+from datetime import date
+
+PERSIAN_DIGITS = '۰۱۲۳۴۵۶۷۸۹'
+
+def generate_persian_number(length=10):
+    """Return a random string of Persian digits with given length."""
+    return ''.join(random.choice(PERSIAN_DIGITS) for _ in range(length))
+
+_digit_map = {str(i): PERSIAN_DIGITS[i] for i in range(10)}
+
+def to_persian_digits(number):
+    """Convert an int or numeric string to Persian digits."""
+    return ''.join(_digit_map.get(ch, ch) for ch in str(number))
+
+# Conversion algorithm adapted from jdatetime to avoid external dependencies
+def gregorian_to_jalali(gy, gm, gd):
+    g_d_m = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+    if gy > 1600:
+        jy = 979
+        gy -= 1600
+    else:
+        jy = 0
+        gy -= 621
+    gy2 = gm > 2 and gy + 1 or gy
+    days = 365 * gy + (gy2 + 3) // 4 - (gy2 + 99) // 100 + (gy2 + 399) // 400 - 80 + gd + g_d_m[gm - 1]
+    jy += 33 * (days // 12053)
+    days %= 12053
+    jy += 4 * (days // 1461)
+    days %= 1461
+    if days > 365:
+        jy += (days - 1) // 365
+        days = (days - 1) % 365
+    if days < 186:
+        jm = 1 + days // 31
+        jd = 1 + days % 31
+    else:
+        jm = 7 + (days - 186) // 30
+        jd = 1 + (days - 186) % 30
+    return jy, jm, jd
+
+def get_persian_date(gregorian_date=None):
+    """Return a Persian date string (YYYY/MM/DD) for the given Gregorian date."""
+    if gregorian_date is None:
+        gregorian_date = date.today()
+    jy, jm, jd = gregorian_to_jalali(gregorian_date.year, gregorian_date.month, gregorian_date.day)
+    formatted = f"{jy:04d}/{jm:02d}/{jd:02d}"
+
+    return to_persian_digits(formatted)

--- a/tests/test_persian_utils.py
+++ b/tests/test_persian_utils.py
@@ -1,0 +1,19 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import re
+from datetime import date
+from persian_utils import generate_persian_number, get_persian_date
+
+PERSIAN_DIGITS = '۰۱۲۳۴۵۶۷۸۹'
+
+def test_generate_persian_number_length_and_digits():
+    num = generate_persian_number()
+    assert len(num) == 10
+    assert all(ch in PERSIAN_DIGITS for ch in num)
+
+def test_get_persian_date_known_value():
+    # Gregorian 2021-03-21 corresponds to Persian 1400/01/01
+    d = date(2021, 3, 21)
+    persian = get_persian_date(d)
+    assert re.match(r'۱۴۰۰/۰۱/۰۱', persian)
+


### PR DESCRIPTION
## Summary
- add `persian_utils.py` with helpers to generate random Persian digits and compute Persian dates
- test those utilities
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d6c4ad50832fab17426b58504f51